### PR TITLE
Patch to allow escaped brackets - issue #15

### DIFF
--- a/src/dust.pegjs
+++ b/src/dust.pegjs
@@ -44,6 +44,8 @@ bodies "bodies"
 reference "reference"
   = ld n:identifier f:filters rd
   { return ["reference", n, f] }
+  / "\\" ld c:(!eol !rd d:. {return d})+ rd
+  {return ["buffer", "{" + c.join("") + "}"]}
 
 partial "partial"
   = ld ">" n:(k:key {return ["literal", k]} / inline) c:context "/" rd

--- a/test/examples.js
+++ b/test/examples.js
@@ -312,6 +312,14 @@ exports.dustExamples = [
               "{!before!}Hello{!after!}",
     context:  {},
     expected: "Hello"
+  },
+  {
+    name:     "escaped-brackets",
+    source:   "Hello \\{foo}",
+    context:  {
+			    foo : 'bar'
+              },
+    expected: "Hello {foo}"
   }
 ];
 


### PR DESCRIPTION
This patch allows dustjs to generate dustjs output, which contains brackets.  I could not quite figure out a fix for escaping { alone, as the peg parser generation would fail.  That would be needed to be able to use dustjs to generate JSON output.
