### PR TITLE
process.binding('evals') is now require('vm')

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,7 +1,7 @@
 var path = require('path'),
     parser = require('./parser'),
     compiler = require('./compiler'),
-    Script = process.binding('evals').Script;
+    vm = require('vm');
 
 require.paths.unshift(path.join(__dirname, '..'));
 
@@ -10,7 +10,7 @@ module.exports = function(dust) {
   dust.compile = compiler.compile;
 
   dust.loadSource = function(source, path) {
-    return Script.runInNewContext(source, {dust: dust}, path);
+    return vm.runInNewContext(source, {dust: dust}, path);
   };
 
   dust.nextTick = process.nextTick;


### PR DESCRIPTION
Supports latest node (0.4.5 and higher)
