### PR TITLE
Allow filters to be used to set default values when a key is falsy

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -321,11 +321,21 @@ Chunk.prototype.reference = function(elem, context, auto, filters) {
       return elem;
     }
   }
+
+/* 
+ *   Modified this so that filters can be used to apply default values
+ *
   if (!dust.isEmpty(elem)) {
     return this.write(dust.filter(elem, auto, filters));
   } else {
     return this;
   }
+ */
+  var filtered = dust.filter(elem, auto, filters);
+  if (!dust.isEmpty(filtered))
+    return this.write(filtered);
+
+  return this;
 };
 
 Chunk.prototype.section = function(elem, context, bodies, params) {


### PR DESCRIPTION
# Commit msg:

Modified the return value of Context.reference to allow filters to be used to set default values
# Reason

When working with JSON api responses sometimes a section of the data structure might be empty and undefined, by default dust will not render anything for these missing keys, so this changes allows for the use of filters to fill in the blanks. Lets say we have a data structure of statistics, some stats are n/a so they are undefined. Using a filters like so:

``` javascript
    dust.filters.num = function (value) {
       return value || "0";
    }
```

We can make sure that the undefined numerical values come up as 0s or any other default value desired.
