### PR TITLE
update for node v0.5.10

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -3,8 +3,6 @@ var path = require('path'),
     compiler = require('./compiler'),
     vm = require('vm');
 
-require.paths.unshift(path.join(__dirname, '..'));
-
 module.exports = function(dust) {
   compiler.parse = parser.parse;
   dust.compile = compiler.compile;


### PR DESCRIPTION
With the node API mostly stable for v0.6, I decided to upgrade and found a problem with dustjs manipulating the now removed require.paths variable.

Thanks for the nice templating engine.
