### PR TITLE
remove require.paths. it has been removed in node 0.6

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -3,7 +3,6 @@ var path = require('path'),
     compiler = require('./compiler'),
     vm = require('vm');
 
-require.paths.unshift(path.join(__dirname, '..'));
 
 module.exports = function(dust) {
   compiler.parse = parser.parse;


### PR DESCRIPTION
furthermore, it's unnecessary.
