### PR TITLE
Enable "compileFn" like functionality for already-compiled functions.

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -27,7 +27,11 @@ dust.renderSource = function(source, context, callback) {
 };
 
 dust.compileFn = function(source, name) {
-  var tmpl = dust.loadSource(dust.compile(source, name));
+  dust.loadFn(dust.compile(source, name));
+};
+
+dust.loadFn = function(source) {
+  var tmpl = dust.loadSource(source);
   return function(context, callback) {
     var master = callback ? new Stub(callback) : new Stream();
     dust.nextTick(function() {
@@ -36,7 +40,6 @@ dust.compileFn = function(source, name) {
     return master;
   }
 };
-
 dust.load = function(name, chunk, context) {
   var tmpl = dust.cache[name];
   if (tmpl) {

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -27,7 +27,7 @@ dust.renderSource = function(source, context, callback) {
 };
 
 dust.compileFn = function(source, name) {
-  dust.loadFn(dust.compile(source, name));
+  return dust.loadFn(dust.compile(source, name));
 };
 
 dust.loadFn = function(source) {
@@ -40,6 +40,7 @@ dust.loadFn = function(source) {
     return master;
   }
 };
+
 dust.load = function(name, chunk, context) {
   var tmpl = dust.cache[name];
   if (tmpl) {


### PR DESCRIPTION
dust.compileFn is incredibly useful, but only accepts uncompiled source.  It would be incredibly helpful to be able to pass in already-compiled source for it to wrap.

It doesn't appear that there's a way to do this without modifying the source, because the "Stub" class is internal/inaccessible.
