### PR TITLE
Update Handlebars

### DIFF
--- a/benchmark/index.html
+++ b/benchmark/index.html
@@ -79,7 +79,7 @@
     <script src="suites/mustache_suite.js"></script>
     <script src="suites/handlebars_suite.js"></script>
     <script src="suites/jquery_suite.js"></script>
-    <script src="http://github.com/wycats/handlebars.js/raw/766497bb553a926c046c5e5b50ee35529d168ba5/lib/handlebars.js"></script>
+    <script src="http://cloud.github.com/downloads/wycats/handlebars.js/handlebars-1.0.0.beta.6.js"></script>
     <script src="http://github.com/janl/mustache.js/raw/master/mustache.js"></script>
     <script src="http://github.com/jquery/jquery-tmpl/raw/master/jquery.tmpl.js"></script>
     <script type="text/javascript" src="http://www.google.com/jsapi"></script>

--- a/benchmark/index.html
+++ b/benchmark/index.html
@@ -74,7 +74,7 @@
 
     <script src="../vendor/jquery.min.js"></script>
     <script src="uubench.js"></script>
-    <script src="../dist/dust-full-0.2.5.min.js"></script>
+    <script src="../dist/dust-full-0.3.0.min.js"></script>
     <script src="suites/dust_suite.js"></script>
     <script src="suites/mustache_suite.js"></script>
     <script src="suites/handlebars_suite.js"></script>


### PR DESCRIPTION
Since many developers use the Dust benchmarks to calibrate their own performance, it's important that the results are up-to-date. The version of Handlebars being tested is quite old and has since improved dramatically in performance.

In the interest of making sure that other developers aren't relying on out-of-date benchmarks, this pull request updates the version of Handlebars to 1.0.0.beta.6.

Happy New Year!
