### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,5 +7,6 @@
   "url"           : "http://akdubya.github.com/dustjs/",
   "keywords"      : ["templates", "views"],
   "main"          : "./lib/dust",
-  "scripts"       : { "test": "make test" }
+  "scripts"       : { "test": "make test" },
+  "repository"    : { "type": "git", "url": "https://github.com/akdubya/dustjs.git" }
 }


### PR DESCRIPTION
This fixes a warning in npm, and makes it much easier to find the repository from the npm module.
